### PR TITLE
Zig 0.13 compatibility

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) !void {
+pub fn build(b: *std.Build) !void {
     // Standard target options allows the person running `zig build` to choose
     // what target to build for. Here we do not override the defaults, which
     // means any target is allowed, and the default is native. Other options
@@ -14,7 +14,7 @@ pub fn build(b: *std.build.Builder) !void {
 
     const lib = b.addStaticLibrary(.{
         .name = "netip",
-        .root_source_file = .{ .path = "src/netip.zig" },
+        .root_source_file = b.path("src/netip.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -25,15 +25,15 @@ pub fn build(b: *std.build.Builder) !void {
     b.installArtifact(lib);
 
     // Register a module so it can be referenced using the package manager.
-    var netip_module = b.createModule(.{
-        .source_file = .{ .path = "src/netip.zig" },
+    const netip_module = b.createModule(.{
+        .root_source_file = b.path("src/netip.zig"),
     });
     try b.modules.put(b.dupe("netip"), netip_module);
 
     // Creates a step for unit testing. This only builds the test executable
     // but does not run it.
     const main_tests = b.addTest(.{
-        .root_source_file = .{ .path = "src/netip.zig" },
+        .root_source_file = b.path("src/netip.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/src/addr.zig
+++ b/src/addr.zig
@@ -3,7 +3,7 @@ const assert = std.debug.assert;
 const math = std.math;
 const mem = std.mem;
 const net = std.net;
-const os = std.os;
+const posix = std.posix;
 const testing = std.testing;
 
 // common address format options
@@ -236,7 +236,7 @@ const ip6 = struct {
         while (i < segs.len) : (i += 1) {
             var j = i;
             while (j < segs.len and segs[j] == 0) : (j += 1) {}
-            var l = j - i;
+            const l = j - i;
             if (l > 1 and l > zero_end - zero_start) {
                 zero_start = i;
                 zero_end = j;
@@ -580,8 +580,8 @@ pub const Addr = union(AddrType) {
     /// Buf is only required for scoped IPv6 addresses.
     pub fn fromNetAddress(a: std.net.Address, buf: []u8) FromNetAddressError!Addr {
         return switch (a.any.family) {
-            os.AF.INET => Addr{ .v4 = Ip4Addr.fromNetAddress(a.in) },
-            os.AF.INET6 => switch (a.in6.sa.scope_id) {
+            posix.AF.INET => Addr{ .v4 = Ip4Addr.fromNetAddress(a.in) },
+            posix.AF.INET6 => switch (a.in6.sa.scope_id) {
                 0 => Addr{ .v6 = Ip6Addr.fromNetAddress(a.in6) },
                 else => Addr{ .v6s = try Ip6AddrScoped.fromNetAddress(a.in6, buf) },
             },


### PR DESCRIPTION
Let me just flag up the change to `std.posix.AF` from `std.os.AF` (which is not available in zig 0.13). Looking at `std.net.Address.any`, (which uses `posix.sockaddr`), I think replacing with `std.posix.AF` makes sense.

https://ziglang.org/documentation/0.13.0/std/#std.posix.AF
https://ziglang.org/documentation/0.13.0/std/#std.net.Address